### PR TITLE
Update Swift Video example app

### DIFF
--- a/swift-video-app/MuxExampleVideoApp/MuxExampleVideoApp.xcodeproj/project.pbxproj
+++ b/swift-video-app/MuxExampleVideoApp/MuxExampleVideoApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		19CDDBF42A72071000A01A60 /* MuxCore in Frameworks */ = {isa = PBXBuildFile; productRef = 19CDDBF32A72071000A01A60 /* MuxCore */; };
 		FA8188EB261E2C2A00FBF62B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8188EA261E2C2A00FBF62B /* AppDelegate.swift */; };
 		FA8188ED261E2C2A00FBF62B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8188EC261E2C2A00FBF62B /* SceneDelegate.swift */; };
 		FA8188EF261E2C2A00FBF62B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8188EE261E2C2A00FBF62B /* ViewController.swift */; };
@@ -57,6 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				19CDDBF42A72071000A01A60 /* MuxCore in Frameworks */,
 				FAC5AC5E263889170052F8A3 /* MUXSDKStats in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -148,6 +150,7 @@
 			name = MuxExampleVideoApp;
 			packageProductDependencies = (
 				FAC5AC5D263889170052F8A3 /* MUXSDKStats */,
+				19CDDBF32A72071000A01A60 /* MuxCore */,
 			);
 			productName = MuxExampleVideoApp;
 			productReference = FA8188E7261E2C2A00FBF62B /* MuxExampleVideoApp.app */;
@@ -222,6 +225,7 @@
 			mainGroup = FA8188DE261E2C2A00FBF62B;
 			packageReferences = (
 				FAC5AC5C263889170052F8A3 /* XCRemoteSwiftPackageReference "mux-stats-sdk-avplayer" */,
+				19CDDBF22A72071000A01A60 /* XCRemoteSwiftPackageReference "stats-sdk-objc" */,
 			);
 			productRefGroup = FA8188E8261E2C2A00FBF62B /* Products */;
 			projectDirPath = "";
@@ -445,7 +449,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CX6AHWLHM6;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MuxExampleVideoApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -464,7 +468,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CX6AHWLHM6;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MuxExampleVideoApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -603,17 +607,30 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		19CDDBF22A72071000A01A60 /* XCRemoteSwiftPackageReference "stats-sdk-objc" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/muxinc/stats-sdk-objc";
+			requirement = {
+				kind = exactVersion;
+				version = 4.5.1;
+			};
+		};
 		FAC5AC5C263889170052F8A3 /* XCRemoteSwiftPackageReference "mux-stats-sdk-avplayer" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/muxinc/mux-stats-sdk-avplayer.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.2.1;
+				kind = exactVersion;
+				version = 3.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		19CDDBF32A72071000A01A60 /* MuxCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 19CDDBF22A72071000A01A60 /* XCRemoteSwiftPackageReference "stats-sdk-objc" */;
+			productName = MuxCore;
+		};
 		FAC5AC5D263889170052F8A3 /* MUXSDKStats */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FAC5AC5C263889170052F8A3 /* XCRemoteSwiftPackageReference "mux-stats-sdk-avplayer" */;

--- a/swift-video-app/MuxExampleVideoApp/MuxExampleVideoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift-video-app/MuxExampleVideoApp/MuxExampleVideoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "MUXSDKStats",
-        "repositoryURL": "https://github.com/muxinc/mux-stats-sdk-avplayer.git",
-        "state": {
-          "branch": null,
-          "revision": "dc7a70d5569184223d5c45f76091addd641e2421",
-          "version": "2.2.1"
-        }
-      },
-      {
-        "package": "MuxCore",
-        "repositoryURL": "https://github.com/muxinc/stats-sdk-objc.git",
-        "state": {
-          "branch": null,
-          "revision": "dce787e34f53a648f42b8b3f1711f7122bdb1506",
-          "version": "3.2.0"
-        }
+  "pins" : [
+    {
+      "identity" : "mux-stats-sdk-avplayer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/muxinc/mux-stats-sdk-avplayer.git",
+      "state" : {
+        "revision" : "b4a0070f35e8407a612eb975a97982aeacd8390c",
+        "version" : "3.2.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "stats-sdk-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/muxinc/stats-sdk-objc.git",
+      "state" : {
+        "revision" : "9e430931d3ef0a2e4607acf953aebe2b0b21c285",
+        "version" : "4.5.1"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/swift-video-app/MuxExampleVideoApp/MuxExampleVideoApp/SceneDelegate.swift
+++ b/swift-video-app/MuxExampleVideoApp/MuxExampleVideoApp/SceneDelegate.swift
@@ -14,6 +14,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var videoViewController: ViewController? = nil
     var avPlayerSavedReference: AVPlayer? = nil
 
+    var enteringPictureInPicture: Bool = false
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -45,19 +47,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Now that the application is coming into the foreground, we should
         // have a avPlayerSavedReference (from the last time it went into the background)
         // Let's re-attached our avPlayerSavedReference onto our ViewController
-        if (videoViewController != nil && avPlayerSavedReference != nil) {
-            avPlayerSavedReference?.currentItem?.preferredPeakBitRate = 0
-            videoViewController!.player = avPlayerSavedReference;
-            avPlayerSavedReference = nil;
+
+        if let videoViewController, let avPlayerSavedReference, !enteringPictureInPicture {
+            avPlayerSavedReference.currentItem?.preferredPeakBitRate = 0
+            videoViewController.playerViewController.player = avPlayerSavedReference
+            self.avPlayerSavedReference = nil
         }
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Detach our avPlayer from the view controller, but save
         // a reference to it so we can re-attach it later
-        if (videoViewController != nil) {
-            avPlayerSavedReference = videoViewController!.player
-            videoViewController?.player = nil
+        if let videoViewController, !enteringPictureInPicture {
+            avPlayerSavedReference = videoViewController.playerViewController.player
+            videoViewController.playerViewController.player = nil
         }
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information

--- a/swift-video-app/MuxExampleVideoApp/MuxExampleVideoApp/ViewController.swift
+++ b/swift-video-app/MuxExampleVideoApp/MuxExampleVideoApp/ViewController.swift
@@ -33,7 +33,6 @@ class ViewController: UIViewController {
         let player = AVPlayer(url: playbackURL)
         playerViewController.player = player
         playerViewController.delegate = self
-        self.playerViewController = playerViewController
 
         displayPlayerViewController()
 


### PR DESCRIPTION
Convert example to use view controller containment instead of subclassing AVPlayerViewController

Clean-up picture-in-picture workaround

Update Data SDK